### PR TITLE
Dodanie operatora porównania w linii 73

### DIFF
--- a/Saper
+++ b/Saper
@@ -70,7 +70,7 @@ class Program
 
 
 
-                        if (count /*??*/ 0)
+                        f(count == 0)
 
                         {
 


### PR DESCRIPTION
Dodano brakujący operator == w warunku if dla sprawdzenia czy liczba sąsiednich bomb wynosi 0. Naprawia Issue #1.